### PR TITLE
[camera_windows] Check string size before Win32 MultiByte <-> WideChar conversions

### DIFF
--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Adds a check for string size before Win32 MultiByte <-> WideChar conversions
+
 ## 0.2.0
 
 **BREAKING CHANGES**:

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.1
+## 0.2.0+1
 
 * Adds a check for string size before Win32 MultiByte <-> WideChar conversions
 

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.0
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_windows/windows/string_utils.cpp
+++ b/packages/camera/camera_windows/windows/string_utils.cpp
@@ -19,10 +19,10 @@ std::string Utf8FromUtf16(const std::wstring& utf16_string) {
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string.data(),
       static_cast<int>(utf16_string.length()), nullptr, 0, nullptr, nullptr);
-  if (target_length == 0) {
-    return std::string();
-  }
   std::string utf8_string;
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
+    return utf8_string;
+  }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string.data(),
@@ -42,10 +42,10 @@ std::wstring Utf16FromUtf8(const std::string& utf8_string) {
   int target_length =
       ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_string.data(),
                             static_cast<int>(utf8_string.length()), nullptr, 0);
-  if (target_length == 0) {
-    return std::wstring();
-  }
   std::wstring utf16_string;
+  if (target_length == 0 || target_length > utf16_string.max_size()) {
+    return utf16_string;
+  }
   utf16_string.resize(target_length);
   int converted_length =
       ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8_string.data(),


### PR DESCRIPTION
This PR adds a check for string max length in Utf8FromUtf16 and Utf16FromUtf8, similar to https://github.com/flutter/flutter/pull/99729.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
